### PR TITLE
Add `PWD` variable support for stdout and stderr

### DIFF
--- a/task.go
+++ b/task.go
@@ -322,6 +322,10 @@ func (t *Task) NewTaskRun() *TaskRun {
 		"TASK": strconv.Itoa(t.Id),
 		"RUN":  strconv.Itoa(run),
 	}
+	if len(t.Pwd) > 0 {
+		vars["PWD"] = t.Pwd
+	}
+	
 	stdout := ReplaceVars(t.Stdout, vars)
 	stderr := ReplaceVars(t.Stderr, vars)
 


### PR DESCRIPTION
This allows us to use the `PWD` variable for `Tasks`:

workspace.json:

```
"Tasks": [
    {
        ...
        "Stdout": "$PWD/$TASK-$RUN.out",
        "Stderr": "$PWD/$TASK-$RUN.err",
        ...
    }
]
```