### PR TITLE
Fix issue with redir() 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.6
 
-RUN go get github.com/ian-kent/websysd
+RUN go get github.com/websysd/websysd
 
 EXPOSE 7050
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ release: release-deps
 	gox ./...
 
 deps:
-	go get github.com/ian-kent/websysd
+	go get github.com/websysd/websysd
 
 test-deps:
 	go get github.com/stretchr/testify

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Like [Marathon](https://github.com/mesosphere/marathon) or [Upstart](https://cod
 
 ### Getting started
 
-Download a [binary release](https://github.com/ian-kent/websysd/releases), or run it with Docker:
+Download a [binary release](https://github.com/websysd/websysd/releases), or run it with Docker:
 
 ```
 docker run -v `pwd`/workspace.json:/workspace.json -v `pwd`/websysd.json:/websysd.json iankent/websysd -workspace=/workspace.json

--- a/Rockerfile
+++ b/Rockerfile
@@ -1,10 +1,10 @@
 # build image
 FROM golang:latest
-RUN go get -v github.com/ian-kent/websysd && \
+RUN go get -v github.com/websysd/websysd && \
     cd /go/src && \
-    CGO_ENABLED=0 go build -a -installsuffix cgo -v -o /go/bin/websysd.o github.com/ian-kent/websysd/main.go \
-    github.com/ian-kent/websysd/bindata.go github.com/ian-kent/websysd/config.go \
-    github.com/ian-kent/websysd/task.go github.com/ian-kent/websysd/vars.go github.com/ian-kent/websysd/AppendSliceValue.go
+    CGO_ENABLED=0 go build -a -installsuffix cgo -v -o /go/bin/websysd.o github.com/websysd/websysd/main.go \
+    github.com/websysd/websysd/bindata.go github.com/websysd/websysd/config.go \
+    github.com/websysd/websysd/task.go github.com/websysd/websysd/vars.go github.com/websysd/websysd/AppendSliceValue.go
 EXPORT /go/bin/ /target
 
 # run image

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ian-kent/go-log/log"
 	gotcha "github.com/ian-kent/gotcha/app"
 	"github.com/ian-kent/gotcha/http"
-	websysd "github.com/ian-kent/websysd/app"
+	websysd "github.com/websysd/websysd/app"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -167,7 +167,11 @@ func redir(session *http.Session) {
 		redir = k
 	}
 
-	session.Redirect(&url.URL{Path: redir})
+	u, err := url.Parse(redir)
+	if err != nil {
+		u = &url.URL{Path: "/"}
+	}
+	session.Redirect(u)
 }
 
 func startTask(session *http.Session) {


### PR DESCRIPTION
**Description**
Fix issue with redir() causing actions (e.g `/enable`)  to redirect to 

`/workspace/%WORKSPACE%/task/%TASK%/%REFERRER_URL%` instead of redirecting to `%REFERRER%`.

`redir()` checks if the request object has a referrer value `session.Request.Referrer()` and passes it to `session.Redirect()` as `u := &url.URL{Path: referrer}`.

But  `u.String()` for the referrer value evaluates to a relative URL, for e.g `./http://localhost:7050`, which causes to HTTP redirect headers to be set relative to the current request.

**Solution:**
We parse the referrer URL using `url.Parse()` before passing to `session.Redirect()`.
If the value failed to parse, it will default to "/".

It should handle the referrer URL properly, for both absolute or relative URLs.

**Other Notes**
Also includes PR #8 changes to fix import references because it is a blocking issue that prevents the project to build.
